### PR TITLE
Cleaned up bot pop stop since it has a lot of extra stuff in it that isn't needed

### DIFF
--- a/src/botpopstop.sp
+++ b/src/botpopstop.sp
@@ -44,7 +44,18 @@ public Action:Event_PlayerJoined(Handle:event, const String:name[], bool:dontBro
 
 	if (iBotHad[leavingBot])
 	{
-		GivePlayerItem(GetClientOfUserId(GetEventInt(event,"player")), iBotHad[leavingBot] == WP_PAIN_PILLS ? "weapon_pain_pills" : "weapon_adrenaline");
+		RestoreItem(GetClientOfUserId(GetEventInt(event), leavingbot));
 		iBotHad[leavingBot] = 0;
 	}
+}
+
+RestoreItem(client, leavingbot)
+{
+	// manually create entity and the equip it since GivePlayerItem() doesn't work in L4D2
+	new entity = CreateEntityByName(iBotHad[leavingBot] == WP_PAIN_PILLS ? "weapon_pain_pills" : "weapon_adrenaline");
+	decl Float:clientOrigin;
+	GetClientAbsOrigin(client, clientOrigin);
+	TeleportEntity(entity, clientOrigin, NULL_VECTOR, NULL_VECTOR);
+	DispatchSpawn(entity)
+	EquipPlayerWeapon(client, entity);
 }


### PR DESCRIPTION
Removed extra include

Preventing bots from getting pills removed since bots are blocked from
taking pills anyways (why bother stopping them two different ways?).
This also removes a timer that wasn't really needed

No longer messes with cheat flag to prevent plugins like KAC from
complaining or causing issues.

Functions with pills and adrenaline now (simple enough, no reason not to
include it since the issue applies to both).
