### PR TITLE
smx given binary attributes in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.smx   binary


### PR DESCRIPTION
Gives a cleaner output if a *.smx is updated and git-diff is used.

(Instead of a bunch of useless information it just says if they are different).  It also prevents git from trying to convert `crlf` to `lf` if they happen to show up in any *.smx
